### PR TITLE
Use standard int types when overloading methods

### DIFF
--- a/ardubsonElement.cpp
+++ b/ardubsonElement.cpp
@@ -133,7 +133,7 @@ char* BSONElement::getString(void)
 int BSONElement::getInt(void)
 {
     int32_t* val = 0;
-    if (isInt())
+    // if (isInt()) // TODO need some way to signal an error (avoid NULL pointer)
     {
         val = (int32_t*) ((char *) &e_data + sizeof(char) + strlen(getKey()) + 1);
     }
@@ -143,7 +143,7 @@ int BSONElement::getInt(void)
 bool BSONElement::getBool(void)
 {
     char* val = 0;
-    if (isInt())
+    // if (isInt()) // TODO need some way to signal an error (avoid NULL pointer)
     {
         val = (char *) &e_data + sizeof(char) + strlen(getKey()) + 1;
     }

--- a/ardubsonElement.cpp
+++ b/ardubsonElement.cpp
@@ -46,7 +46,7 @@ void BSONElement::Value(const char* value, int size)
     put(value, size);
 }
 
-void BSONElement::Value(int value)
+void BSONElement::Value(int16_t value)
 {
     return Value((int32_t) value);
 }

--- a/ardubsonElement.h
+++ b/ardubsonElement.h
@@ -28,7 +28,7 @@ class BSONElement
         BSONElement& Key(const char *key);
         void Value(const char *value);
         void Value(const char *value, int size);
-        void Value(int value);
+        void Value(int16_t value);
         void Value(int32_t value);
         void Value(int64_t value);
         void Value(bool value);

--- a/ardubsonObjBuilder.cpp
+++ b/ardubsonObjBuilder.cpp
@@ -81,7 +81,7 @@ BSONObjBuilder& BSONObjBuilder::append(const char *key, bool value)
 }
 
 // Append int, the value will be saved as int32 type
-BSONObjBuilder& BSONObjBuilder::append(const char *key, int value)
+BSONObjBuilder& BSONObjBuilder::append(const char *key, int16_t value)
 {
     return append(key, (int32_t) value);
 }

--- a/ardubsonObjBuilder.h
+++ b/ardubsonObjBuilder.h
@@ -38,7 +38,7 @@ class BSONObjBuilder: public BSONDocument
         BSONObjBuilder& append(const char *key, bool value);
 
         /* Append numbers */
-        BSONObjBuilder& append(const char *key, int value);
+        BSONObjBuilder& append(const char *key, int16_t value);
         BSONObjBuilder& append(const char *key, int32_t value);
         BSONObjBuilder& append(const char *key, int64_t value);
 


### PR DESCRIPTION
This pull request solves #1 in a very simple way, allowing the library to work with three different types: `int16_t`, `int32_t` and `int64_t`, as it was intended to.

Additionally, this pull request prevents from accessing not initialized pointers. The problem was caused by  `BSONElement::getInt()` and `BSONElement::getBool()`. There is still some work to do there in order to signal the error to the user.