### PR TITLE
Stopped zeroing of floats in IEEE754tools.cpp

### DIFF
--- a/src/IEEE754tools.cpp
+++ b/src/IEEE754tools.cpp
@@ -40,8 +40,8 @@ void dumpDBL(struct _DBL dbl)
 void float2DoublePacked(float number, byte* bar, int byteOrder)
 {
     _FLOATCONV fl;
-    fl.f = number;
     fl.p = IEEEfloat();
+    fl.f = number;
     _DBLCONV dbl;
     dbl.p.filler = 0;
     dbl.p.s = fl.p.s;


### PR DESCRIPTION
I experienced incorrect float-to-double conversions such as the float value 5632.20 being converted to 0x38 00 00 00 00 00 00 00 (it is supposed to be 0x40 B6 00 32 40 00 00 00). I noticed that the union `_FLOATCONV f1` had all its bits reset to zero after `fl.p = IEEEfloat()`. Assigning the float `number` to `f1` after assigning the result of `IEEEfloat()` to `f1` fixed the problem for me.

If it helps, I am using Arduino IDE 1.8.15 on Linux Mint 20.1 to program an Arduino Mega.

### Before fixing the problem:
![problem](https://user-images.githubusercontent.com/72779561/124221829-7a01f980-dace-11eb-91b5-f0ba3e5a5215.png)

### After fixing the problem:
![no-problem](https://user-images.githubusercontent.com/72779561/124221828-7a01f980-dace-11eb-8a03-96677ae19993.png)